### PR TITLE
Add support for inline assertions

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -60,15 +60,23 @@ export interface Report {
 export function extractAssertions(scanner: ts.Scanner, source: ts.SourceFile): Assertion[] {
   const assertions = [] as Assertion[];
 
+  let isFirstTokenOnLine = true;
+  let lastLine = -1;
+
   while (scanner.scan() !== ts.SyntaxKind.EndOfFileToken) {
+    const pos = scanner.getTokenPos();
+    let { line } = source.getLineAndCharacterOfPosition(pos);
+    isFirstTokenOnLine = (line !== lastLine);
+    lastLine = line;
+
     if (scanner.getToken() === ts.SyntaxKind.SingleLineCommentTrivia) {
       const commentText = scanner.getTokenText();
       const m = commentText.match(/^\/\/ \$Expect(Type|Error) (.*)/);
       if (!m) continue;
 
-      const pos = scanner.getTokenPos();
-      let { line } = source.getLineAndCharacterOfPosition(pos);
-      line++;  // the assertion applies to the next line.
+      if (isFirstTokenOnLine) {
+        line++;  // the assertion applies to the next line.
+      }
 
       const [, kind, text] = m;
       if (kind === 'Type') {
@@ -88,12 +96,11 @@ export function attachNodesToAssertions(
 ): NodedAssertion[] {
   const nodedAssertions = [] as NodedAssertion[];
 
+  // Match assertions to the first node that appears on the line they apply to.
   function collectNodes(node: ts.Node) {
-    if (node.kind >= ts.SyntaxKind.VariableStatement &&
-        node.kind <= ts.SyntaxKind.DebuggerStatement) {
+    if (node.kind !== ts.SyntaxKind.SourceFile) {
       const pos = node.getStart();
       const { line } = source.getLineAndCharacterOfPosition(pos);
-
       const assertionIndex = _.findIndex(assertions, {line});
       if (assertionIndex >= 0) {
         const assertion = assertions[assertionIndex];

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -183,3 +183,19 @@ export function generateReport(
 
   return { numSuccesses, failures };
 }
+
+/**
+ * Check a single TypeScript source file for typings assertions and errors.
+ *
+ * The file passes the checks if report.failures.length === 0.
+ */
+export default function checkFile(
+  source: ts.SourceFile,
+  scanner: ts.Scanner,
+  checker: ts.TypeChecker,
+  diagnostics: ts.Diagnostic[]
+): Report {
+  const assertions = extractAssertions(scanner, source);
+  const nodedAssertions = attachNodesToAssertions(source, checker, assertions);
+  return generateReport(checker, nodedAssertions, diagnostics);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@
 
 import * as ts from 'typescript';
 
-import { extractAssertions, attachNodesToAssertions, generateReport } from './checker';
+import checkFile from './checker';
 
 const [,, tsFile] = process.argv;
 
@@ -21,17 +21,14 @@ const host = ts.createCompilerHost(options, true);
 
 const program = ts.createProgram([tsFile], options, host);
 
-const checker = program.getTypeChecker();
-
 const source = program.getSourceFile(tsFile);
 const scanner = ts.createScanner(
     ts.ScriptTarget.ES5, false, ts.LanguageVariant.Standard, source.getFullText());
 
-const assertions = extractAssertions(scanner, source);
-const nodedAssertions = attachNodesToAssertions(source, checker, assertions);
-
+const checker = program.getTypeChecker();
 const diagnostics = ts.getPreEmitDiagnostics(program);
-const report = generateReport(checker, nodedAssertions, diagnostics);
+
+const report = checkFile(source, scanner, checker, diagnostics);
 
 for (const failure of report.failures) {
   const { line } = failure;

--- a/tests/basics/inline-assertion.ts
+++ b/tests/basics/inline-assertion.ts
@@ -1,0 +1,15 @@
+// This checks the types of parameters to a callback using inline assertions.
+
+function mapObject<T, U>(
+  o: T,
+  callback: (val: T[keyof T], key: keyof T, collection: T) => U
+): {[k in keyof T]: U} {
+  return {} as any;
+}
+
+// $ExpectType { a: string; b: string; }
+mapObject({a: 1, b: 2}, (
+  val,  // $ExpectType number
+  key,  // $ExpectType "a" | "b"
+  c,  // $ExpectType { a: number; b: number; }
+) => '' + val);

--- a/tests/basics/inline-assertion.ts.out
+++ b/tests/basics/inline-assertion.ts.out
@@ -1,0 +1,1 @@
+tests/basics/inline-assertion.ts: 4 / 4 checks passed.


### PR DESCRIPTION
Fixes #1 

- An assertion on its own line applies to the next line.
- An assertion at the end of a line applies to the line on which it appears.

This matches how people typically use comments.

```ts
// $ExpectType { a: string; b: string; }
mapObject({a: 1, b: 2}, (
  val,  // $ExpectType number
  key,  // $ExpectType "a" | "b"
  c,  // $ExpectType { a: number; b: number; }
) => '' + val);
```

The first assertion applies to the next line (`mapObject`) while the others are inline.

I reworked the logic for matching assertions to nodes to be simpler. It doesn't look for expression anymore, just the first node (other than the whole program) that appears on the line.