### PR TITLE
Ignore leading whitespace for full-line assertions.

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -64,12 +64,16 @@ export function extractAssertions(scanner: ts.Scanner, source: ts.SourceFile): A
   let lastLine = -1;
 
   while (scanner.scan() !== ts.SyntaxKind.EndOfFileToken) {
+    const token = scanner.getToken();
+    if (token === ts.SyntaxKind.WhitespaceTrivia) continue;  // ignore leading whitespace.
+
     const pos = scanner.getTokenPos();
     let { line } = source.getLineAndCharacterOfPosition(pos);
+
     isFirstTokenOnLine = (line !== lastLine);
     lastLine = line;
 
-    if (scanner.getToken() === ts.SyntaxKind.SingleLineCommentTrivia) {
+    if (token === ts.SyntaxKind.SingleLineCommentTrivia) {
       const commentText = scanner.getTokenText();
       const m = commentText.match(/^\/\/ \$Expect(Type|Error) (.*)/);
       if (!m) continue;

--- a/tests/ramda.ts
+++ b/tests/ramda.ts
@@ -1,0 +1,12 @@
+const R = {
+  isArrayLike(x: any) { return true; },
+};
+
+() => {
+  // $ExpectType boolean
+  R.isArrayLike('a');
+  // $ExpectType boolean
+  R.isArrayLike([1,2,3]);
+  // $ExpectType boolean
+  R.isArrayLike([]);
+};

--- a/tests/ramda.ts.out
+++ b/tests/ramda.ts.out
@@ -1,0 +1,1 @@
+tests/ramda.ts: 3 / 3 checks passed.

--- a/update-tests.sh
+++ b/update-tests.sh
@@ -9,5 +9,11 @@ done
 
 # This shows changes and sets the exit code.
 set -o errexit
-git status
 git --no-pager diff -- tests
+
+git status
+if [ -n "$(git status --porcelain)" ]; then
+  # this will catch a missing .ts.out file, for example.
+  echo Unexpected changes
+  exit 1
+fi


### PR DESCRIPTION
Fixes #14 

@tycho01 this is why your assertions weren't getting attached to nodes.