### PR TITLE
Move $ExpectError behind a flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,16 @@ const argv = yargs
     .usage('Usage: <file> [options]')
     .alias('p', 'project')
     .describe('p', 'Path to the tsconfig.json file for your project')
+    .boolean('allow-expect-error')
+    .describe('allow-expect-error',
+              'Enable $ExpectError assertions. Setting this option means that ' +
+              'it\'s possible for code to be accepted by typings-checker but not ' +
+              'tsc.')
     .argv;
 
 const [tsFile] = argv._;
 const { project } = argv;
+const allowExpectError = argv['allow-expect-error'];
 
 // read options from a tsconfig.json file.
 // TOOD: make this optional, just like tsc.
@@ -42,7 +48,11 @@ const scanner = ts.createScanner(
 const checker = program.getTypeChecker();
 const diagnostics = ts.getPreEmitDiagnostics(program);
 
-const report = checkFile(source, scanner, checker, diagnostics);
+const typingsOptions = {
+  allowExpectError,
+};
+
+const report = checkFile(source, scanner, checker, diagnostics, typingsOptions);
 
 for (const failure of report.failures) {
   const { line } = failure;

--- a/update-tests.sh
+++ b/update-tests.sh
@@ -5,7 +5,7 @@ set +o errexit
 
 for test in $(find tests -name '*.ts'); do
   echo $test
-  node dist/index.js --project tests/tsconfig.json $test > $test.out 2>&1
+  node dist/index.js --allow-expect-error --project tests/tsconfig.json $test > $test.out 2>&1
 done
 
 # test wrong file path


### PR DESCRIPTION
This disables `$ExpectError` by default. The rationale is that if you only use `$ExpectType`, you can use `typings-checker` in addition to `tsc`, rather than as a replacement for it. This should make it easier to use with DefinitelyTyped.

Closes #18 